### PR TITLE
add isActive field

### DIFF
--- a/src/graphql/aclGates.js
+++ b/src/graphql/aclGates.js
@@ -54,10 +54,12 @@ export const isActiveGate = ({
   const _id = args._id || args.record._id;
   const isActive = args.isActive || args.record.isActive;
   const isPublic = args.isPublic || args.record.isPublic;
-  const currentIsActive = await models.User.findOne({ _id });
+  const current = await models.User.findOne({ _id });
 
-  if (isActive !== currentIsActive.isActive) throw error(errMsgTglActivity);
-  if (!isActive && isPublic) throw error(errMsgTglPrivacy);
+  const isTogglingActive = isActive && isActive !== current.isActive;
+  const isDeactivatedTryPublic = !current.isActive && isPublic;
+  if (isTogglingActive) throw error(errMsgTglActivity);
+  if (isDeactivatedTryPublic) throw error(errMsgTglPrivacy);
 };
 
 export const selfGate = ({ models, errMsg = defaultErrorMessage }) => async ({

--- a/src/graphql/aclGates.js
+++ b/src/graphql/aclGates.js
@@ -32,7 +32,7 @@ const error = (message = defaultErrorMessage, status = 403) => {
 const defaultErrorMessage = 'Access denied';
 
 // gates
-export const isAdminGate = ({ errMsg }) => async ({ args, context }) => {
+export const isAdminGate = ({ errMsg }) => async ({ context }) => {
   if (!isAdmin({ context })) {
     throw error(errMsg);
   }
@@ -46,20 +46,18 @@ export const idGate = ({ models, errMsg }) => async ({ args, context }) => {
   }
 };
 
-export const isActiveGate = ({ models, errMsgTglActivity, errMsgTglPrivacy }) => async ({
-  args,
-  context
-}) => {
+export const isActiveGate = ({
+  models,
+  errMsgTglActivity,
+  errMsgTglPrivacy
+}) => async ({ args, context }) => {
   const _id = args._id || args.record._id;
   const isActive = args.isActive || args.record.isActive;
   const isPublic = args.isPublic || args.record.isPublic;
-  const currentIsActive = await models.User.findOne({ _id }).then(
-    user => user.isActive
-  );
-  if (!isActive) {
-    if (isActive !== currentIsActive) throw error(errMsgTglActivity);
-    if(isPublic) throw error(errMsgTglPrivacy);
-  }
+  const currentIsActive = await models.User.findOne({ _id });
+
+  if (isActive !== currentIsActive.isActive) throw error(errMsgTglActivity);
+  if (!isActive && isPublic) throw error(errMsgTglPrivacy);
 };
 
 export const selfGate = ({ models, errMsg = defaultErrorMessage }) => async ({

--- a/src/graphql/aclGates.js
+++ b/src/graphql/aclGates.js
@@ -32,10 +32,7 @@ const error = (message = defaultErrorMessage, status = 403) => {
 const defaultErrorMessage = 'Access denied';
 
 // gates
-export const isAdminGate = ({ errMsg }) => async ({
-  args,
-  context
-}) => {
+export const isAdminGate = ({ errMsg }) => async ({ args, context }) => {
   if (!isAdmin({ context })) {
     throw error(errMsg);
   }
@@ -48,17 +45,20 @@ export const idGate = ({ models, errMsg }) => async ({ args, context }) => {
     throw error(errMsg);
   }
 };
-export const isActiveGate = ({ models, errMsg }) => async ({
+
+export const isActiveGate = ({ models, errMsgTglActivity, errMsgTglPrivacy }) => async ({
   args,
   context
 }) => {
   const _id = args._id || args.record._id;
   const isActive = args.isActive || args.record.isActive;
+  const isPublic = args.isPublic || args.record.isPublic;
   const currentIsActive = await models.User.findOne({ _id }).then(
     user => user.isActive
   );
-  if (!isActive && isActive !== currentIsActive) {
-    throw error(errMsg);
+  if (!isActive) {
+    if (isActive !== currentIsActive) throw error(errMsgTglActivity);
+    if(isPublic) throw error(errMsgTglPrivacy);
   }
 };
 

--- a/src/graphql/index.js
+++ b/src/graphql/index.js
@@ -13,12 +13,11 @@ import {
 } from './aclGates';
 import { composeWithMongoose } from 'graphql-compose-mongoose';
 
-const restrict = (resolver, ...restrictions) => {
-  return resolver.wrapResolve(next => async rp => {
+const restrict = (resolver, ...restrictions) =>
+  resolver.wrapResolve(next => async rp => {
     await Promise.all(restrictions.map(r => r(rp)));
     return next(rp);
   });
-};
 
 /**
  * Builds the models once, but allows us to change the body of the schema when we want.
@@ -31,7 +30,7 @@ const restrict = (resolver, ...restrictions) => {
  * @param models
  * @param tags
  */
-export const createSchema = function({ models }) {
+export const createSchema = ({ models }) => {
   const UserTC = generateUserTC({ models });
   const UserRestrictedTC = composeWithMongoose(models.User, {
     schemaComposer: new SchemaComposer(),
@@ -90,16 +89,18 @@ export const createSchema = function({ models }) {
       idGate({ models, errMsg: "You can't change your ego id" }),
       isActiveGate({
         models,
-        errMsgTglActivity: "You need to be admin to deactivate a user's account",
-        errMsgTglPrivacy: "You cannot make public a inactive account. Activate it first"
+        errMsgTglActivity:
+          "You need to be admin to deactivate a user's account",
+        errMsgTglPrivacy:
+          'You cannot make public a inactive account. Activate it first'
       })
     ),
     userUpdateAdmin: restrict(
       UserTC.getResolver('toggleActivity'),
       validTokenGate({ errMsg: invalidTokenErrorMessage }),
       isAdminGate({
-        errMsg: 'Only a ADMIN user can change the activity status of a profile'
-      }),
+        errMsg: 'Only an ADMIN user can change the activity status of a profile'
+      })
     )
   });
 

--- a/src/graphql/index.js
+++ b/src/graphql/index.js
@@ -1,23 +1,23 @@
-import {GQC, SchemaComposer} from 'graphql-compose';
+import { GQC, SchemaComposer } from 'graphql-compose';
 
 import generateUserTC from './schema/User';
 import {
-    adminOrAppGate,
-    adminOrAppOrPublicGate,
-    adminOrSelfGate,
-    idGate,
-    isActiveGate,
-    isAdminGate,
-    selfGate,
-    validTokenGate,
+  adminOrAppGate,
+  adminOrAppOrPublicGate,
+  adminOrSelfGate,
+  idGate,
+  isActiveGate,
+  isAdminGate,
+  selfGate,
+  validTokenGate
 } from './aclGates';
-import {composeWithMongoose} from "graphql-compose-mongoose";
+import { composeWithMongoose } from 'graphql-compose-mongoose';
 
 const restrict = (resolver, ...restrictions) => {
-    return resolver.wrapResolve(next => async rp => {
-        await Promise.all(restrictions.map(r => r(rp)));
-        return next(rp);
-    });
+  return resolver.wrapResolve(next => async rp => {
+    await Promise.all(restrictions.map(r => r(rp)));
+    return next(rp);
+  });
 };
 
 /**
@@ -31,68 +31,77 @@ const restrict = (resolver, ...restrictions) => {
  * @param models
  * @param tags
  */
-export const createSchema = function ({models}) {
-    const UserTC = generateUserTC({models});
-    const UserRestrictedTC = composeWithMongoose(models.User, {schemaComposer:new SchemaComposer(), name:'UserRestrictedModel', fields: {remove: ['email', 'egoId', 'institutionalEmail']}});
+export const createSchema = function({ models }) {
+  const UserTC = generateUserTC({ models });
+  const UserRestrictedTC = composeWithMongoose(models.User, {
+    schemaComposer: new SchemaComposer(),
+    name: 'UserRestrictedModel',
+    fields: { remove: ['email', 'egoId', 'institutionalEmail'] }
+  });
 
-    const invalidTokenErrorMessage = 'You must provide valid token';
+  const invalidTokenErrorMessage = 'You must provide valid token';
 
-    GQC.rootQuery().addFields({
-        self: restrict(
-            UserTC.getResolver('self'),
-            validTokenGate({errMsg: invalidTokenErrorMessage}),
-        ),
-        user: restrict(
-            UserRestrictedTC.getResolver('findById'),   //builtin api of graphql compose mongoose https://github.com/graphql-compose/graphql-compose-mongoose
-            adminOrAppOrPublicGate({
-                models,
-                errMsg:
-                    'Access denied. This profile is not public. (You may also access this resource with Admin privileges).',
-            }),
-        ),
-        fullUser: restrict(
-            UserTC.getResolver('findById'),   //builtin api of graphql compose mongoose https://github.com/graphql-compose/graphql-compose-mongoose
-            adminOrAppGate({
-                errMsg:
-                    'Access denied. You need Admin privileges to access this resource',
-            }),
-        ),
-        users: restrict(
-            UserTC.getResolver('pagination'),
-            adminOrAppGate({
-                errMsg:
-                    'Access denied. You need Admin privileges to access this resource',
-            }),
-        )
-    });
+  GQC.rootQuery().addFields({
+    self: restrict(
+      UserTC.getResolver('self'),
+      validTokenGate({ errMsg: invalidTokenErrorMessage })
+    ),
+    user: restrict(
+      UserRestrictedTC.getResolver('findById'), //builtin api of graphql compose mongoose https://github.com/graphql-compose/graphql-compose-mongoose
+      adminOrAppOrPublicGate({
+        models,
+        errMsg:
+          'Access denied. This profile is not public. (You may also access this resource with Admin privileges).'
+      })
+    ),
+    fullUser: restrict(
+      UserTC.getResolver('findById'), //builtin api of graphql compose mongoose https://github.com/graphql-compose/graphql-compose-mongoose
+      adminOrAppGate({
+        errMsg:
+          'Access denied. You need Admin privileges to access this resource'
+      })
+    ),
+    users: restrict(
+      UserTC.getResolver('pagination'),
+      adminOrAppGate({
+        errMsg:
+          'Access denied. You need Admin privileges to access this resource'
+      })
+    )
+  });
 
-    GQC.rootMutation().addFields({
-        userCreate: restrict(
-            UserTC.getResolver('createOne'),
-            validTokenGate({errMsg: invalidTokenErrorMessage}),
-        ),
-        userRemove: restrict(
-            UserTC.getResolver('removeById'),
-            validTokenGate({errMsg: invalidTokenErrorMessage}),
-            adminOrSelfGate({
-                models,
-                errMsg: `Access denied. You need admin access to perform this action on someone else's account`,
-            }),
-        ),
-        userUpdate: restrict(
-            UserTC.getResolver('updateById'),
-            validTokenGate({errMsg: invalidTokenErrorMessage}),
-            selfGate({models, errMsg: `You can't edit someone elses profile`}),
-            idGate({models, errMsg: "You can't change your ego id"}),
-            isActiveGate({models, errMsg: "You need to be admin to deactivate a user's account"})
-        ),
-        userUpdateAdmin: restrict(
-            UserTC.getResolver('toggleActivity'),
-            validTokenGate({errMsg: invalidTokenErrorMessage}),
-            isAdminGate({ errMsg: "Only a ADMIN user can change the activity status of a profile"}),
-        ),
-    });
+  GQC.rootMutation().addFields({
+    userCreate: restrict(
+      UserTC.getResolver('createOne'),
+      validTokenGate({ errMsg: invalidTokenErrorMessage })
+    ),
+    userRemove: restrict(
+      UserTC.getResolver('removeById'),
+      validTokenGate({ errMsg: invalidTokenErrorMessage }),
+      adminOrSelfGate({
+        models,
+        errMsg: `Access denied. You need admin access to perform this action on someone else's account`
+      })
+    ),
+    userUpdate: restrict(
+      UserTC.getResolver('updateById'),
+      validTokenGate({ errMsg: invalidTokenErrorMessage }),
+      selfGate({ models, errMsg: `You can't edit someone elses profile` }),
+      idGate({ models, errMsg: "You can't change your ego id" }),
+      isActiveGate({
+        models,
+        errMsgTglActivity: "You need to be admin to deactivate a user's account",
+        errMsgTglPrivacy: "You cannot make public a inactive account. Activate it first"
+      })
+    ),
+    userUpdateAdmin: restrict(
+      UserTC.getResolver('toggleActivity'),
+      validTokenGate({ errMsg: invalidTokenErrorMessage }),
+      isAdminGate({
+        errMsg: 'Only a ADMIN user can change the activity status of a profile'
+      }),
+    )
+  });
 
-    return GQC.buildSchema();
-
+  return GQC.buildSchema();
 };

--- a/src/graphql/schema/User/index.js
+++ b/src/graphql/schema/User/index.js
@@ -1,6 +1,16 @@
 import { composeWithMongoose } from 'graphql-compose-mongoose';
 
-const self = UserModel => ({context}) => UserModel.findOne({egoId: context.jwt.sub});
+const self = UserModel => ({ context }) =>
+  UserModel.findOne({ egoId: context.jwt.sub });
+
+const admin = UserModel => ({ args }) =>
+  UserModel.findByIdAndUpdate(
+    { _id: args._id },
+    args.isActive
+      ? { isActive: args.isActive }
+      : { isActive: args.isActive, isPublic: false },
+    { new: true }
+  );
 
 export default ({ models }) => {
   const UserTC = composeWithMongoose(models.User, {});
@@ -9,7 +19,18 @@ export default ({ models }) => {
     kind: 'query',
     name: 'self',
     type: UserTC,
-    resolve: self(models.User),
+    resolve: self(models.User)
+  });
+
+  UserTC.addResolver({
+    kind: 'mutation',
+    args: {
+      _id: 'MongoID!',
+      isActive: 'Boolean'
+    },
+    name: 'toggleActivity',
+    type: UserTC,
+    resolve: admin(models.User)
   });
 
   return UserTC;

--- a/src/graphql/schema/User/index.js
+++ b/src/graphql/schema/User/index.js
@@ -3,7 +3,7 @@ import { composeWithMongoose } from 'graphql-compose-mongoose';
 const self = UserModel => ({ context }) =>
   UserModel.findOne({ egoId: context.jwt.sub });
 
-const admin = UserModel => ({ args }) =>
+const toggleActivity = UserModel => ({ args }) =>
   UserModel.findByIdAndUpdate(
     { _id: args._id },
     args.isActive
@@ -30,7 +30,7 @@ export default ({ models }) => {
     },
     name: 'toggleActivity',
     type: UserTC,
-    resolve: admin(models.User)
+    resolve: toggleActivity(models.User)
   });
 
   return UserTC;

--- a/src/schema/User.js
+++ b/src/schema/User.js
@@ -118,6 +118,12 @@ export const userSchema = new mongoose.Schema(
       default: false
     },
 
+    isActive: {
+      //is the profile active?
+      type: 'boolean',
+      default: true
+    },
+
     // a bit about yourself
     bio: {
       type: 'String',

--- a/src/services/csvGenerator.js
+++ b/src/services/csvGenerator.js
@@ -12,6 +12,7 @@ export const generateMemberList = (members, res) => {
     csvStream.write({
       id: doc._id,
       isPublic: doc.isPublic,
+      isActive: doc.isActive,
       title: doc.title,
       firstName: doc.firstName,
       lastName: doc.lastName,


### PR DESCRIPTION
new Boolean field added to persona - `isActive`

- At user creation, `isActive` is set by default to true
- `userUpdate` Mutation will no permit to modify this parameter
- `userUpdateAdmin` mutation is only accessible to Admin users and for now can only set the `isActive` parameter
    -  takes two parameters(_id, and the filed to be updated, `isActive` for now)
    - is `isActive` is set to false, `isPublic` is also set to false. (not true for vice-versa)


ex. of a GraphiQL query:

```
mutation{
  userUpdateAdmin(_id:"5e4ae87b9a4715687e0fe625", isActive: true){
    _id
    isPublic
    isActive
    firstName
    lastName
    ...
  }
}
```

 